### PR TITLE
Implement "shown by" for application groups

### DIFF
--- a/language/src/main/scala/com/ossuminc/riddl/language/AST.scala
+++ b/language/src/main/scala/com/ossuminc/riddl/language/AST.scala
@@ -3524,6 +3524,7 @@ object AST {
     loc: At,
     alias: String,
     id: Identifier,
+    shownBy: Option[java.net.URL] = None,
     elements: Seq[OccursInGroup] = Seq.empty[OccursInGroup],
     brief: Option[LiteralString] = None,
     description: Option[Description] = None

--- a/language/src/main/scala/com/ossuminc/riddl/language/parsing/ApplicationParser.scala
+++ b/language/src/main/scala/com/ossuminc/riddl/language/parsing/ApplicationParser.scala
@@ -42,11 +42,11 @@ private[parsing] trait ApplicationParser {
 
   private def group[u: P]: P[Group] = {
     P(
-      location ~ groupAliases ~ identifier ~/ is ~ open ~
+      location ~ groupAliases ~ identifier ~/ (Keywords.shown ~ Readability.byAsIn ~ httpUrl).? ~/ is ~ open ~
         (undefined(Seq.empty[OccursInGroup]) | groupDefinitions) ~
         close ~ briefly ~ description
-    ).map { case (loc, alias, id, elements, brief, description) =>
-      Group(loc, alias, id, elements, brief, description)
+    ).map { case (loc, alias, id, url, elements, brief, description) =>
+      Group(loc, alias, id, url, elements, brief, description)
     }
   }
 

--- a/language/src/main/scala/com/ossuminc/riddl/language/parsing/Readability.scala
+++ b/language/src/main/scala/com/ossuminc/riddl/language/parsing/Readability.scala
@@ -12,6 +12,7 @@ object Readability {
   def at[u: P]: P[Unit] = keyword("at")
   def by[u: P]: P[Unit] = keyword("by")
   def byAs[u: P]: P[Unit] = Keywords.keywords(StringIn("by", "as"))
+  def byAsIn[u: P]: P[Unit] = Keywords.keywords(StringIn("by", "as", "in"))
   def byFromAs[u: P]: P[Unit] = { Keywords.keywords(StringIn("by", "from", "as")).? }
 
   def for_[u: P]: P[Unit] = keyword("for")

--- a/language/src/test/scala/com/ossuminc/riddl/language/parsing/ApplicationParsingTest.scala
+++ b/language/src/test/scala/com/ossuminc/riddl/language/parsing/ApplicationParsingTest.scala
@@ -48,5 +48,17 @@ class ApplicationParsingTest extends ParsingTest with Matchers {
           succeed
       }
     }
+    "supports 'shown by' in groups" in {
+      val input =
+        """
+          |domain foo {
+          |  application ignore {
+          |    group Mickey shown by https://pngimg.com/uploads/mickey_mouse/mickey_mouse_PNG54.png is {
+          |      ???
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+    }
   }
 }


### PR DESCRIPTION
This allows figma references to be made for pages and other larger portions of the application.