### PR TITLE
Remove all @SuppressWarning and prepare for Scalafix

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,23 +1,19 @@
 // .scalafix.conf
 rules = [
-  RemoveUnused
-  SortImports
-  ExplicitResultTypes
+  "com.github.xuwei-k::scalafix-rules"
   "github:ohze/scalafix-rules/FinalObject"
-  fix.scala213.DottyMigrate
-  //  fix.scala213.NullaryOverride
 ]
 //NullaryOverride.mode = Rewrite
-ExplicitResultTypes {
-  memberVisibility = [] # only rewrite implicit members
-  skipSimpleDefinitions = []
-}
-ExplicitImplicitTypes.symbolReplacements {
-  "scala/concurrent/ExecutionContextExecutor#" = "scala/concurrent/ExecutionContext#"
-}
-RemoveUnused.imports = true
-RemoveUnused.privates = false
-RemoveUnused.locals = false
+//ExplicitResultTypes {
+//  memberVisibility = [] # only rewrite implicit members
+//  skipSimpleDefinitions = []
+//}
+//ExplicitImplicitTypes.symbolReplacements {
+//  "scala/concurrent/ExecutionContextExecutor#" = "scala/concurrent/ExecutionContext#"
+//}
+//RemoveUnused.imports = true
+//RemoveUnused.privates = false
+//RemoveUnused.locals = false
 
 //ignored files
 ignored-files = [

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import com.ossuminc.sbt.OssumIncPlugin.autoImport.With.wartRemover
+import com.ossuminc.sbt.helpers.Publishing
 import com.ossuminc.sbt.helpers.RootProjectInfo.Keys.{gitHubOrganization, gitHubRepository}
 import com.ossuminc.sbt.helpers.WartRemover.Keys
 import org.scoverage.coveralls.Imports.CoverallsKeys.*
@@ -18,7 +19,7 @@ lazy val nonWarts: Seq[Wart] = Seq(
 
 
 lazy val riddl: Project = Root("", "riddl", startYr = startYear)
-  .configure(With.noPublishing, With.git, With.dynver)
+  .configure(Publishing.configure, With.git, With.dynver)
   .settings(
     ThisBuild / gitHubRepository := "riddl",
     ThisBuild / gitHubOrganization := "ossuminc",

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,9 @@
+import com.ossuminc.sbt.OssumIncPlugin.autoImport.With.wartRemover
 import com.ossuminc.sbt.helpers.RootProjectInfo.Keys.{gitHubOrganization, gitHubRepository}
+import com.ossuminc.sbt.helpers.WartRemover.Keys
 import org.scoverage.coveralls.Imports.CoverallsKeys.*
+import wartremover.Wart
+import wartremover.Wart.*
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 (Global / excludeLintKeys) ++= Set(mainClass)
@@ -7,6 +11,11 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 enablePlugins(OssumIncPlugin)
 
 lazy val startYear: Int = 2019
+
+lazy val nonWarts: Seq[Wart] = Seq(
+  ToString, MutableDataStructures, GlobalExecutionContext
+)
+
 
 lazy val riddl: Project = Root("", "riddl", startYr = startYear)
   .configure(With.noPublishing, With.git, With.dynver)
@@ -33,7 +42,7 @@ lazy val riddl: Project = Root("", "riddl", startYr = startYear)
 lazy val Utils = config("utils")
 lazy val utils: Project = Module("utils", "riddl-utils")
   .enablePlugins(OssumIncPlugin)
-  .configure(With.typical, With.build_info)
+  .configure(With.typical, With.build_info, With.coverage(70))
   .settings(
     buildInfoPackage := "com.ossuminc.riddl.utils",
     buildInfoObject := "RiddlBuildInfo",
@@ -44,8 +53,7 @@ lazy val utils: Project = Module("utils", "riddl-utils")
 val Language = config("language")
 lazy val language: Project = Module("language", "riddl-language")
   .enablePlugins(OssumIncPlugin)
-  .configure(With.typical)
-  .configure(With.coverage(65))
+  .configure(With.typical, With.coverage(65))
   .settings(
     scalacOptions += "-explain",
     coverageExcludedPackages := "<empty>;.*BuildInfo;.*Terminals",

--- a/commands/src/main/scala/com/ossuminc/riddl/commands/CommandOptions.scala
+++ b/commands/src/main/scala/com/ossuminc/riddl/commands/CommandOptions.scala
@@ -248,7 +248,6 @@ object CommandOptions {
     }
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
   val commandOptionsParser: OParser[Unit, CommandOptions] = {
     val plugins = Plugin.loadPluginsFrom[CommandPlugin[CommandOptions]]()
     val list =

--- a/commands/src/main/scala/com/ossuminc/riddl/commands/RepeatCommand.scala
+++ b/commands/src/main/scala/com/ossuminc/riddl/commands/RepeatCommand.scala
@@ -146,7 +146,6 @@ class RepeatCommand
    * @return
    * Either a set of Messages on error or a Unit on success
    */
-  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   override def run(
     options: Options,
     commonOptions: CommonOptions,

--- a/diagrams/src/main/scala/com/ossuminc/riddl/diagrams/mermaid/UseCaseDiagram.scala
+++ b/diagrams/src/main/scala/com/ossuminc/riddl/diagrams/mermaid/UseCaseDiagram.scala
@@ -18,7 +18,6 @@ import scala.reflect.ClassTag
   * @param useCase
   * The UseCase from the AST to which this diagram applies
   */
-@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
 case class UseCaseDiagram(sds: UseCaseDiagramSupport, useCase: UseCase) extends FileBuilder {
 
   private final val indent_per_level = 4

--- a/hugo/src/main/scala/com/ossuminc/riddl/hugo/HugoPass.scala
+++ b/hugo/src/main/scala/com/ossuminc/riddl/hugo/HugoPass.scala
@@ -41,7 +41,6 @@ case class HugoOutput(
   messages: Messages = Messages.empty
 ) extends PassOutput
 
-@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
 case class HugoPass(
   input: PassInput,
   outputs: PassesOutput,

--- a/hugo/src/main/scala/com/ossuminc/riddl/hugo/MarkdownWriter.scala
+++ b/hugo/src/main/scala/com/ossuminc/riddl/hugo/MarkdownWriter.scala
@@ -420,8 +420,7 @@ case class MarkdownWriter(
       }
     }
   }
-
-  @SuppressWarnings(Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps"))
+  
   def emitDescription(d: Option[Description], level: Int = 2): this.type = {
     d match {
       case None => this
@@ -679,7 +678,6 @@ case class MarkdownWriter(
     this
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps"))
   private def emitInputOutput(
     input: Option[Aggregation],
     output: Option[Aggregation]
@@ -843,7 +841,6 @@ case class MarkdownWriter(
     emitTerms(application.terms)
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps"))
   def emitEpic(epic: Epic, stack: Seq[Definition]): this.type = {
     containerHead(epic, "Epic")
     val parents = passUtilities.makeStringParents(stack)

--- a/hugo/src/main/scala/com/ossuminc/riddl/hugo/ToDoListPass.scala
+++ b/hugo/src/main/scala/com/ossuminc/riddl/hugo/ToDoListPass.scala
@@ -48,7 +48,6 @@ case class ToDoListPass(input: PassInput, outputs: PassesOutput, options: HugoCo
     }
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
   private def mkAuthor(authors: Seq[AuthorRef], parents: Seq[Definition]): Seq[String] = {
     if authors.isEmpty then Seq.empty
     else

--- a/language/src/main/scala/com/ossuminc/riddl/language/AST.scala
+++ b/language/src/main/scala/com/ossuminc/riddl/language/AST.scala
@@ -279,7 +279,7 @@ object AST {
   }
 
   sealed trait NamedValue extends RiddlValue with WithIdentifier
-  
+
   sealed trait NamedContainer[CV <: RiddlValue] extends NamedValue with Container[CV]
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////// WITHS
@@ -857,7 +857,6 @@ object AST {
   /** Base trait of an expression that defines a type
     */
   sealed trait TypeExpression extends RiddlValue {
-    @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
     def isAssignmentCompatible(other: TypeExpression): Boolean = {
       (other == this) || (other.getClass == this.getClass) ||
       (other.getClass == classOf[Abstract]) ||
@@ -875,7 +874,6 @@ object AST {
 
   sealed trait NumericType extends TypeExpression {
 
-    @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
     override def isAssignmentCompatible(other: TypeExpression): Boolean = {
       super.isAssignmentCompatible(other) || other.isInstanceOf[NumericType]
     }
@@ -1283,7 +1281,6 @@ object AST {
     override def format: String =
       s"$kind(${pattern.map(_.format).mkString(", ")})"
 
-    @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
     override def isAssignmentCompatible(other: TypeExpression): Boolean = {
       super.isAssignmentCompatible(other) || other.isInstanceOf[String_]
     }
@@ -1301,7 +1298,6 @@ object AST {
 
     override def format: String = s"$kind(${entityPath.format})"
 
-    @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
     override def isAssignmentCompatible(other: TypeExpression): Boolean = {
       super.isAssignmentCompatible(other) || other.isInstanceOf[String_] ||
       other.isInstanceOf[Pattern]
@@ -1358,7 +1354,6 @@ object AST {
       if min.isEmpty && max.isEmpty then kind else s"$kind(${min.getOrElse("")},${max.getOrElse("")})"
     }
 
-    @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
     override def isAssignmentCompatible(other: TypeExpression): Boolean = {
       super.isAssignmentCompatible(other) || other.isInstanceOf[Pattern]
     }
@@ -1385,7 +1380,6 @@ object AST {
   }
 
   case class UserId(loc: At) extends PredefinedType {
-    @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
     override def isAssignmentCompatible(other: TypeExpression): Boolean = {
       super.isAssignmentCompatible(other) || {
         other match
@@ -1435,7 +1429,6 @@ object AST {
     override def format: String = s"$kind($min,$max)"
     inline override def kind: String = "Range"
 
-    @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
     override def isAssignmentCompatible(other: TypeExpression): Boolean = {
       super.isAssignmentCompatible(other) || other.isInstanceOf[NumericType]
     }
@@ -1500,7 +1493,6 @@ object AST {
     */
   case class Date(loc: At) extends TimeType {
 
-    @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
     override def isAssignmentCompatible(other: TypeExpression): Boolean = {
       super.isAssignmentCompatible(other) || other.isInstanceOf[DateTime] ||
       other.isInstanceOf[TimeStamp] || other.isInstanceOf[String_] ||
@@ -1515,7 +1507,6 @@ object AST {
     */
   case class Time(loc: At) extends TimeType {
 
-    @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
     override def isAssignmentCompatible(other: TypeExpression): Boolean = {
       super.isAssignmentCompatible(other) || other.isInstanceOf[DateTime] ||
       other.isInstanceOf[TimeStamp] || other.isInstanceOf[String_] ||
@@ -1530,7 +1521,6 @@ object AST {
     */
   case class DateTime(loc: At) extends TimeType {
 
-    @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
     override def isAssignmentCompatible(other: TypeExpression): Boolean = {
       super.isAssignmentCompatible(other) || other.isInstanceOf[Date] || other.isInstanceOf[DateTime] ||
       other.isInstanceOf[ZonedDateTime] || other.isInstanceOf[TimeStamp] || other.isInstanceOf[String_] ||
@@ -1556,7 +1546,6 @@ object AST {
     *   The location of the timestamp
     */
   case class TimeStamp(loc: At) extends TimeType {
-    @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
     override def isAssignmentCompatible(other: TypeExpression): Boolean = {
       super.isAssignmentCompatible(other) || other.isInstanceOf[DateTime] ||
       other.isInstanceOf[Date] || other.isInstanceOf[String_] ||
@@ -3834,7 +3823,6 @@ object AST {
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////// FUNCTIONS
 
-  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf", "org.wartremover.warts.IsInstanceOf"))
   def findAuthors(
     defn: RiddlValue,
     parents: Seq[Container[RiddlValue]]

--- a/language/src/main/scala/com/ossuminc/riddl/language/At.scala
+++ b/language/src/main/scala/com/ossuminc/riddl/language/At.scala
@@ -30,7 +30,6 @@ case class At(source: RiddlParserInput, offset: Int = 0) extends Ordered[At] {
   @targetName("plus")
   def +(int: Int): At = At(source, offset + int)
 
-  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   override def equals(obj: Any): Boolean = {
     if obj.getClass != classOf[At] then { false }
     else {

--- a/language/src/main/scala/com/ossuminc/riddl/language/parsing/CommonParser.scala
+++ b/language/src/main/scala/com/ossuminc/riddl/language/parsing/CommonParser.scala
@@ -15,7 +15,6 @@ import java.nio.file.Files
 import scala.reflect.{ClassTag, classTag}
 
 /** Common Parsing Rules */
-@SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf", "org.wartremover.warts.Throw"))
 private[parsing] trait CommonParser extends NoWhiteSpaceParsers {
 
   def author[u: P]: P[Author] = {

--- a/passes/src/main/scala/com/ossuminc/riddl/passes/resolve/ResolutionPass.scala
+++ b/passes/src/main/scala/com/ossuminc/riddl/passes/resolve/ResolutionPass.scala
@@ -28,7 +28,6 @@ object ResolutionPass extends PassInfo {
 }
 
 /** The Reference Resolution Pass */
-@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
 case class ResolutionPass(input: PassInput, outputs: PassesOutput) extends Pass(input, outputs) with UsageResolution {
 
   override def name: String = ResolutionPass.name
@@ -340,12 +339,9 @@ case class ResolutionPass(input: PassInput, outputs: PassesOutput) extends Pass(
   private case class AnchorNotFoundInSymTab(topName: String) extends AnchorCase
   private case class AnchorNotFoundInParents(topName: String) extends AnchorCase
   private case class AnchorNotFoundAnywhere(topName: String) extends AnchorCase
-  private case class AnchorIsAmbiguous(topName: String, list: List[SymTabItem])
-      extends AnchorCase
-  private case class AnchorFoundInSymTab(anchor: Definition, anchor_parents: Parents)
-      extends AnchorCase
-  private case class AnchorFoundInParents(anchor: Definition, anchor_parents: Parents)
-      extends AnchorCase
+  private case class AnchorIsAmbiguous(topName: String, list: List[SymTabItem]) extends AnchorCase
+  private case class AnchorFoundInSymTab(anchor: Definition, anchor_parents: Parents) extends AnchorCase
+  private case class AnchorFoundInParents(anchor: Definition, anchor_parents: Parents) extends AnchorCase
   private case class AnchorIsRoot(anchor: Definition, anchor_parents: Parents) extends AnchorCase
 
   private def findAnchorInParents(
@@ -383,7 +379,6 @@ case class ResolutionPass(input: PassInput, outputs: PassesOutput) extends Pass(
     }
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
   private def findAnchor[T <: Definition: ClassTag](
     pathId: PathIdentifier,
     parents: Seq[Definition]
@@ -414,7 +409,6 @@ case class ResolutionPass(input: PassInput, outputs: PassesOutput) extends Pass(
         AnchorNotFoundAnywhere("<unknown>")
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.IterableOps"))
   private def resolvePathFromAnchor[T <: Definition: ClassTag](
     pathId: PathIdentifier,
     parents: Parents,
@@ -468,7 +462,6 @@ case class ResolutionPass(input: PassInput, outputs: PassesOutput) extends Pass(
     else Seq.empty[Definition]
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
   private def checkResultingPath[T <: Definition: ClassTag](
     pathId: PathIdentifier,
     parents: Seq[Definition],
@@ -500,7 +493,6 @@ case class ResolutionPass(input: PassInput, outputs: PassesOutput) extends Pass(
 
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
   private def checkThatPathIdMatchesFoundParentStack[T <: Definition: ClassTag](
     pathId: PathIdentifier,
     parents: Parents,
@@ -671,7 +663,6 @@ case class ResolutionPass(input: PassInput, outputs: PassesOutput) extends Pass(
     }
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
   private def resolveAPathId[T <: Definition: ClassTag](
     pathId: PathIdentifier,
     parents: Seq[Definition]

--- a/passes/src/main/scala/com/ossuminc/riddl/passes/resolve/UsageResolution.scala
+++ b/passes/src/main/scala/com/ossuminc/riddl/passes/resolve/UsageResolution.scala
@@ -23,7 +23,6 @@ trait UsageBase {
 /** Validation State for Uses/UsedBy Tracking. During parsing, when usage is detected, call associateUsage. After
   * parsing ends, call checkUnused. Collects entities, types and functions too
   */
-@SuppressWarnings(Array("org.wartremover.warts.Var"))
 trait UsageResolution extends UsageBase {
 
   def commonOptions: CommonOptions

--- a/passes/src/main/scala/com/ossuminc/riddl/passes/validate/ValidationPass.scala
+++ b/passes/src/main/scala/com/ossuminc/riddl/passes/validate/ValidationPass.scala
@@ -26,7 +26,6 @@ object ValidationPass extends PassInfo {
   * @param input
   *   Input from previous passes
   */
-@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
 case class ValidationPass(
   input: PassInput,
   outputs: PassesOutput
@@ -146,7 +145,6 @@ case class ValidationPass(
     }
   }
 
-  @SuppressWarnings(Array("org.wartremover.wart.IsInstanceOf"))
   private def validateOnMessageClause(omc: OnMessageClause, parents: Seq[Definition]): Unit = {
     checkDefinition(parents, omc)
     if omc.msg.nonEmpty then {
@@ -364,7 +362,6 @@ case class ValidationPass(
     checkDescription(ai)
   }
 
-  @SuppressWarnings(Array("org.wartremover.wart.IsInstanceOf"))
   private def validateType(
     t: Type,
     parents: Seq[Definition]
@@ -750,7 +747,6 @@ case class ValidationPass(
     checkDescription(uc)
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
   private def validateArbitraryInteraction(
     origin: Option[Definition],
     destination: Option[Definition],
@@ -826,7 +822,6 @@ case class ValidationPass(
     }
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
   private def validateInteraction(interaction: Interaction, parents: Seq[Definition]): Unit = {
     val useCase = parents.head
     checkDescription(interaction)

--- a/prettify/src/main/scala/com/ossuminc/riddl/prettify/RiddlFileEmitter.scala
+++ b/prettify/src/main/scala/com/ossuminc/riddl/prettify/RiddlFileEmitter.scala
@@ -16,7 +16,6 @@ import com.ossuminc.riddl.utils.{Logger, TextFileWriter}
 import java.nio.charset.StandardCharsets
 
 /** Unit Tests For RiddlFileEmitter */
-@SuppressWarnings(Array("org.wartremover.warts.Var"))
 case class RiddlFileEmitter(filePath: Path) extends TextFileWriter {
   private var indentLevel: Int = 0
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.ossuminc" % "sbt-ossuminc" % "0.6.2-0-4ea9f399-20240113-1526")
+addSbtPlugin("com.ossuminc" % "sbt-ossuminc" % "0.7.1")
 
 // This enables sbt-bloop to create bloop config files for Metals editors
 // Uncomment locally if you use metals, otherwise don't slow down other

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.ossuminc" % "sbt-ossuminc" % "0.6.1")
+addSbtPlugin("com.ossuminc" % "sbt-ossuminc" % "0.6.2-0-4ea9f399-20240113-1526")
 
 // This enables sbt-bloop to create bloop config files for Metals editors
 // Uncomment locally if you use metals, otherwise don't slow down other

--- a/stats/src/main/scala/com/ossuminc/riddl/stats/StatsPass.scala
+++ b/stats/src/main/scala/com/ossuminc/riddl/stats/StatsPass.scala
@@ -53,7 +53,6 @@ case class DefinitionStats(
   numStatements: Long = 0
 )
 
-@SuppressWarnings(Array("org.wartremover.warts.Var"))
 case class KindStats(
   var count: Long = 0,
   var numEmpty: Long = 0,
@@ -83,7 +82,6 @@ case class StatsOutput(
 ) extends CollectingPassOutput[DefinitionStats]
 
 /** Unit Tests For StatsPass */
-@SuppressWarnings(Array("org.wartremover.warts.Var"))
 case class StatsPass(input: PassInput, outputs: PassesOutput) extends CollectingPass[DefinitionStats](input, outputs) {
 
   def name: String = StatsPass.name

--- a/testkit/src/main/scala/com/ossuminc/riddl/testkit/ValidatingTest.scala
+++ b/testkit/src/main/scala/com/ossuminc/riddl/testkit/ValidatingTest.scala
@@ -32,7 +32,6 @@ abstract class ValidatingTest extends AnyWordSpec with Matchers with com.ossumin
     else Right(result)
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
   def parseAndValidate(
     input: String,
     origin: String,

--- a/utils/src/main/scala/com/ossuminc/riddl/utils/Logger.scala
+++ b/utils/src/main/scala/com/ossuminc/riddl/utils/Logger.scala
@@ -23,10 +23,9 @@ object Logger {
   case object Warning extends Lvl
   case object Info extends Lvl
 
-  val nl = System.getProperty("line.separator")
+  val nl: String = System.getProperty("line.separator")
 }
 
-@SuppressWarnings(Array("org.wartremover.warts.Var"))
 trait Logger {
   import Logger.*
 
@@ -57,10 +56,10 @@ trait Logger {
       s"[$level] $s"
     else
       val prefix = level match {
-        case Logger.Severe  => s"${RED_B}${BLACK}"
-        case Logger.Error   => s"${RED}"
-        case Logger.Warning => s"${YELLOW}"
-        case Logger.Info    => s"${BLUE}"
+        case Logger.Severe  => s"$RED_B$BLACK"
+        case Logger.Error   => s"$RED"
+        case Logger.Warning => s"$YELLOW"
+        case Logger.Info    => s"$BLUE"
       }
       val lines = s.split(nl)
       val head = s"$prefix$BOLD[$level] ${lines.head}$RESET"

--- a/utils/src/main/scala/com/ossuminc/riddl/utils/PathUtils.scala
+++ b/utils/src/main/scala/com/ossuminc/riddl/utils/PathUtils.scala
@@ -25,7 +25,7 @@ object PathUtils {
     */
   def copyResource(resourceName: String, destination: Path): Unit = {
     val src = this.getClass.getClassLoader.getResourceAsStream(resourceName)
-    require(src != null, s"Failed to open resource ${resourceName}")
+    require(src != null, s"Failed to open resource $resourceName")
     Files.copy(src, destination, StandardCopyOption.REPLACE_EXISTING)
   }
 
@@ -58,7 +58,6 @@ object PathUtils {
     } else { "" }
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   def compareDirectories(
     a: Path,
     b: Path

--- a/utils/src/main/scala/com/ossuminc/riddl/utils/Plugin.scala
+++ b/utils/src/main/scala/com/ossuminc/riddl/utils/Plugin.scala
@@ -26,7 +26,6 @@ object Plugin {
   def loadPluginsFrom[T <: PluginInterface: ClassTag](
     pluginsDir: Path = pluginsDir
   ): List[T] = {
-    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     val clazz = classTag[T].runtimeClass.asInstanceOf[Class[T]]
     loadSpecificPluginsFrom[T](clazz, pluginsDir)
   }

--- a/utils/src/main/scala/com/ossuminc/riddl/utils/PluginClassLoader.scala
+++ b/utils/src/main/scala/com/ossuminc/riddl/utils/PluginClassLoader.scala
@@ -10,7 +10,6 @@ import java.net.URLClassLoader
 
 /** Loads a plugin using a [[java.net.URLClassLoader]].
   */
-@SuppressWarnings(Array("org.wartremover.warts.Var"))
 case class PluginClassLoader(urls: List[URL], parentClassLoader: ClassLoader)
     extends URLClassLoader(urls.toArray, parentClassLoader) {
   require(urls.forall(_.getProtocol == "jar"))

--- a/utils/src/main/scala/com/ossuminc/riddl/utils/StringHelpers.scala
+++ b/utils/src/main/scala/com/ossuminc/riddl/utils/StringHelpers.scala
@@ -16,7 +16,6 @@ object StringHelpers {
     val buf = new StringBuffer(1024)
     val nl = System.lineSeparator()
 
-    @SuppressWarnings(Array("org.wartremover.warts.Any"))
     def doIt(
       obj: Any,
       depth: Int,

--- a/utils/src/main/scala/com/ossuminc/riddl/utils/Tar.scala
+++ b/utils/src/main/scala/com/ossuminc/riddl/utils/Tar.scala
@@ -17,7 +17,6 @@ object Tar {
 
   final val bufferSize: Int = 1024 * 1024 // 1 MB
 
-  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   def untar(tarFile: Path, destDir: Path): Either[String, Int] = {
     val fname = tarFile.getFileName.toString
     val fi = Files.newInputStream(tarFile)
@@ -36,7 +35,7 @@ object Tar {
 
     taris match
       case None =>
-        Left(s"Tar file name ${tarFile} must end in .tar.gz or .tar")
+        Left(s"Tar file name $tarFile must end in .tar.gz or .tar")
       case Some(taris) =>
         var counter = 0
         var tae = taris.getNextTarEntry

--- a/utils/src/main/scala/com/ossuminc/riddl/utils/TextFileWriter.scala
+++ b/utils/src/main/scala/com/ossuminc/riddl/utils/TextFileWriter.scala
@@ -38,7 +38,6 @@ object TextFileWriter {
     val textLength = template.length
     val builder = new mutable.StringBuilder(textLength)
 
-    @SuppressWarnings(Array("org.wartremover.warts.Null"))
     @tailrec def loop(text: String): mutable.StringBuilder = {
       if text.isEmpty then { builder }
       else if text.startsWith("${") then {

--- a/utils/src/test/scala/com/ossuminc/riddl/utils/InterruptTest.scala
+++ b/utils/src/test/scala/com/ossuminc/riddl/utils/InterruptTest.scala
@@ -33,7 +33,7 @@ class InterruptTest extends AnyWordSpec with Matchers {
             case x: Throwable             => fail(s"Wrong exception: $x")
           }
           while !interrupt.ready do Thread.sleep(5)
-          interrupt.cancel
+          interrupt.cancel()
           Await.result(f2, 2.seconds)
         case None => fail("Unexpected result")
       }


### PR DESCRIPTION
WartRemover was determined to not support Scala 3 well. Neither does Scalafix for that matter.
Simply pull out all the WartRemover @SuppressWarning annotations and wait for the tools to catch up.