### PR TITLE
Parallel Include Improvements

### DIFF
--- a/commands/src/main/scala/com/ossuminc/riddl/commands/CommandOptions.scala
+++ b/commands/src/main/scala/com/ossuminc/riddl/commands/CommandOptions.scala
@@ -206,7 +206,7 @@ object CommandOptions {
           sortMessagesByLocation = sortMessages.getOrElse(false),
           groupMessagesByKind,
           noANSIMessages,
-          maxParallelParsing = maxParallel.getOrElse(4),
+          maxParallelParsing = maxParallel.getOrElse(1),
           maxIncludeWait = FiniteDuration(maxIncludeWait, "seconds"),
           warningsAreFatal = warnsAreFatal.getOrElse(false)
         )

--- a/language/src/main/scala/com/ossuminc/riddl/language/parsing/TopLevelParser.scala
+++ b/language/src/main/scala/com/ossuminc/riddl/language/parsing/TopLevelParser.scala
@@ -15,7 +15,6 @@ import fastparse.MultiLineWhitespace.*
 
 import java.io.File
 import java.nio.file.{Files, Path}
-import java.util.concurrent.{ExecutorService, Executors}
 import scala.concurrent.ExecutionContext
 
 /** Top level parsing rules */
@@ -80,8 +79,8 @@ object TopLevelParser {
     withVerboseFailures: Boolean = false
   ): Either[Messages, Root] = {
     Timer.time(s"parse ${input.origin}", commonOptions.showTimes) {
-      val es: ExecutorService = Executors.newWorkStealingPool(commonOptions.maxParallelParsing)
-      implicit val _: ExecutionContext = ExecutionContext.fromExecutorService(es)
+      // val es: ExecutorService = Executors.newWorkStealingPool(commonOptions.maxParallelParsing)
+      implicit val _: ExecutionContext = ExecutionContext.Implicits.global
       val tlp = new TopLevelParser(input, commonOptions)
       tlp.parseRoot(withVerboseFailures)
     }


### PR DESCRIPTION
Fixes some time-out issues because of using Java's Executor not Scala's ExecutionContext. 
Also made it avoid using Futures/parallelism at all if maxParallelParsing is < 2