### PR TITLE
Implement ULID support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,8 @@ lazy val language_cp: CrossProject = CrossModule("language", "riddl-language")(J
     },
     coverageExcludedPackages := "<empty>;$anon",
     libraryDependencies ++= Dep.testing ++ Seq(Dep.fastparse),
-    libraryDependencies += "org.wvlet.airframe" %% "airframe-ulid" % "24.9.0",
+    libraryDependencies += "org.wvlet.airframe" %% "airframe-ulid" % V.airframe_ulid,
+    libraryDependencies += "org.wvlet.airframe" %% "airframe-json" % V.airframe_json,
     libraryDependencies += Dep.commons_io % Test
   )
   .jsConfigure(With.js("RIDDL: language", withCommonJSModule = true))

--- a/language/jvm/src/test/scala/com/ossuminc/riddl/language/ASTTestJVM.scala
+++ b/language/jvm/src/test/scala/com/ossuminc/riddl/language/ASTTestJVM.scala
@@ -9,14 +9,13 @@ import wvlet.airframe.ulid.ULID
 class ASTTestJVM extends TestingBasis {
 
   "RiddlValue" must {
-    "reject incorrectly typed values in attachments" in {
-      val container = SimpleContainer(Contents.empty)
-      container.put("this", "that")
-      intercept[ClassCastException] {
-        val result: Option[Double] = container.get[Double]("this")
-        val timesTwo = result.get * 2.0
-        println(timesTwo)
-      }
+    "allow attachments to be added programatically" in {
+      val container = Entity(At.empty, Identifier.empty)
+      val a = StringAttachment(At.empty, Identifier(At.empty,"foo"), "application/json", LiteralString(At.empty,"{}"))
+      container.descriptives += a
+      container.descriptives.filter[StringAttachment] match
+        case Seq(value) if value == a => succeed
+        case _  => fail("No go")
     }
   }
   "Include" should {

--- a/language/shared/src/main/scala/com/ossuminc/riddl/language/parsing/CommonParser.scala
+++ b/language/shared/src/main/scala/com/ossuminc/riddl/language/parsing/CommonParser.scala
@@ -11,6 +11,7 @@ import com.ossuminc.riddl.language.AST.{Comment, *}
 import com.ossuminc.riddl.language.At
 import fastparse.{P, *}
 import fastparse.MultiLineWhitespace.*
+import wvlet.airframe.ulid.ULID
 
 import java.net.URI
 import java.nio.file.Files
@@ -169,8 +170,40 @@ private[parsing] trait CommonParser
     }
   }
 
+  def mimeType[u: P]: P[String] = {
+    P(
+      ("application" | "audio" | "example" | "font" |
+        "image" | "model" | "text" | "video") ~~ "/" ~~ CharIn("a-z\\-.+").rep(1)
+    ).!
+  }
+
+  def fileAttachment[u: P]: P[FileAttachment] = {
+    P(
+      location ~ Keywords.attachment ~ identifier ~ is ~ mimeType ~ in ~ Keywords.file ~ literalString
+    ).map { case (loc, id, mimeType, fileName) =>
+      FileAttachment(loc, id, mimeType, fileName)
+    }
+  }
+
+  def stringAttachment[u: P]: P[StringAttachment] =
+    P(
+      location ~ Keywords.attachment ~ identifier ~ is ~ mimeType ~ as ~ literalString
+    ).map { case (loc, id, mimeType, value) =>
+      StringAttachment(loc, id, mimeType, value)
+    }
+    
+  def ulidAttachment[u:P]: P[ULIDAttachment] =
+    P(
+      location ~ Keywords.attachment ~ "ULID" ~ is ~ literalString 
+    ).map { case (loc, ulidString) =>
+      val ulid = ULID.fromString(ulidString.s)
+      ULIDAttachment(loc, ulid)  
+    }
+  end ulidAttachment
+
   def descriptive[u: P]: P[Descriptives] =
-    P(briefDescription | description | term | authorRef).asInstanceOf[P[Descriptives]]
+    P(briefDescription | description | term | authorRef | fileAttachment | stringAttachment | ulidAttachment)
+      .asInstanceOf[P[Descriptives]]
 
   def withDescriptives[u: P]: P[Seq[Descriptives]] = {
     P(
@@ -287,4 +320,5 @@ private[parsing] trait CommonParser
       ShownBy(loc, urls)
     }
   }
+
 }

--- a/language/shared/src/main/scala/com/ossuminc/riddl/language/parsing/Keywords.scala
+++ b/language/shared/src/main/scala/com/ossuminc/riddl/language/parsing/Keywords.scala
@@ -64,6 +64,8 @@ object Keywords {
   def append[u: P]: P[Unit] = keyword(Keyword.append)
 
   def application[u: P]: P[Unit] = keyword(Keyword.application)
+  
+  def attachment[u:P]: P[Unit] = keyword(Keyword.attachment)
 
   def author[u: P]: P[Unit] = keyword(Keyword.author)
 
@@ -332,6 +334,7 @@ object Keyword {
   final val any = "any"
   final val append = "append"
   final val application = "application"
+  final val attachment = "attachment"
   final val author = "author"
   final val become = "become"
   final val benefit = "benefit"

--- a/language/shared/src/test/scala/com/ossuminc/riddl/language/ASTAccessTest.scala
+++ b/language/shared/src/test/scala/com/ossuminc/riddl/language/ASTAccessTest.scala
@@ -7,23 +7,18 @@ import org.scalatest.matchers.must.Matchers
 import wvlet.airframe.ulid.ULID
 
 class ASTAccessTest extends AsyncFunSpec with Matchers:
-  describe("RiddlValue") {
-    it("must allow put/get/has of ULID values") {
-      val node = SimpleContainer(Contents.empty)
-      val ulid: ULID = ULID.newULID
-      node.put[ULID]("ulid", ulid)
-      node.has("ulid") must be(true)
-      node.get[ULID]("ulid") match
-        case Some(ulid2) =>
-          ulid2 must be(ulid)
-        case None => fail("Unable to retrieve ulid")
-      end match
+  describe("ULID") {
+    it("must automatically provide a ulid value") {
+      val node = Context(At.empty, Identifier(At.empty, "foo"))
+      val created = node.ulid.epochMillis
+      val now = java.time.Instant.now().toEpochMilli
+      assert(now-created < 10)
     }
-    it("must accept storage of arbitrary named values in a map") {
-      val container = SimpleContainer(Contents.empty)
-      container.put("this", "that")
-      val result = container.get("this")
-      result must be(Some("that"))
+    it("must accept storage of arbitrary named string values") {
+      val node = Context(At.empty, Identifier(At.empty, "foo"))
+      node.descriptives += StringAttachment(At.empty, Identifier(At.empty, "foo"), "application/json",
+        LiteralString(At.empty, "{}"))
+      succeed
     }
   }
 end ASTAccessTest

--- a/language/shared/src/test/scala/com/ossuminc/riddl/language/ASTAccessTest.scala
+++ b/language/shared/src/test/scala/com/ossuminc/riddl/language/ASTAccessTest.scala
@@ -12,12 +12,16 @@ class ASTAccessTest extends AsyncFunSpec with Matchers:
       val node = Context(At.empty, Identifier(At.empty, "foo"))
       val created = node.ulid.epochMillis
       val now = java.time.Instant.now().toEpochMilli
-      assert(now-created < 10)
+      assert(now - created < 25)
     }
     it("must accept storage of arbitrary named string values") {
       val node = Context(At.empty, Identifier(At.empty, "foo"))
-      node.descriptives += StringAttachment(At.empty, Identifier(At.empty, "foo"), "application/json",
-        LiteralString(At.empty, "{}"))
+      node.descriptives += StringAttachment(
+        At.empty,
+        Identifier(At.empty, "foo"),
+        "application/json",
+        LiteralString(At.empty, "{}")
+      )
       succeed
     }
   }

--- a/language/shared/src/test/scala/com/ossuminc/riddl/language/ASTTest.scala
+++ b/language/shared/src/test/scala/com/ossuminc/riddl/language/ASTTest.scala
@@ -16,20 +16,6 @@ import wvlet.airframe.ulid.ULID
 /** Unit Tests For Abstract Syntax Tree */
 class ASTTest extends TestingBasis {
 
-  "RiddlValue" should {
-    "accept storage of arbitrary named values in a map" in {
-      val container = SimpleContainer(Contents.empty)
-      container.put("this", "that")
-      val result = container.get("this")
-      result must be(Some("that"))
-    }
-    "associate ULID with a Node" in {
-      val container = SimpleContainer(Contents.empty)
-      val ulid: ULID = ULID.newULID
-      container.put[ULID]("ulid", ulid)
-    }
-  }
-
   "Descriptions" should {
     "have empty Description.empty" in {
       Description.empty.format mustBe ""
@@ -176,8 +162,14 @@ class ASTTest extends TestingBasis {
     WriteStatement(At.empty, "put", LiteralString(At(), "what"), typeRef)
   )
   val function: Function =
-    Function(At.empty, Identifier(At(), "Lambda"), None, None, statements.asInstanceOf[Contents[FunctionContents]],
-      (brief.toSeq ++ description.toSeq).toContents.asInstanceOf[Contents[Descriptives]])
+    Function(
+      At.empty,
+      Identifier(At(), "Lambda"),
+      None,
+      None,
+      statements.asInstanceOf[Contents[FunctionContents]],
+      (brief.toSeq ++ description.toSeq).toContents.asInstanceOf[Contents[Descriptives]]
+    )
   val functionRef: FunctionRef = FunctionRef(At.empty, PathIdentifier(At.empty, Seq("Lambda")))
   val onClauses: Contents[OnClause] = Contents(
     OnInitializationClause(At.empty, statements),
@@ -185,8 +177,8 @@ class ASTTest extends TestingBasis {
     OnOtherClause(At.empty, statements),
     OnTerminationClause(At.empty, statements)
   )
-  val handler: Handler = Handler(At.empty, Identifier(At(), "handler"),
-    onClauses.asInstanceOf[Contents[HandlerContents]])
+  val handler: Handler =
+    Handler(At.empty, Identifier(At(), "handler"), onClauses.asInstanceOf[Contents[HandlerContents]])
   val entity: Entity = Entity(At.empty, Identifier(At.empty, "Entity"), Contents(handler))
   val handlerRef: HandlerRef = HandlerRef(At.empty, PathIdentifier(At(), Seq("handler")))
   val sagaStep: SagaStep = SagaStep(At.empty, Identifier(At.empty, "sagaStep"))

--- a/passes/shared/src/main/scala/com/ossuminc/riddl/passes/prettify/RiddlFileEmitter.scala
+++ b/passes/shared/src/main/scala/com/ossuminc/riddl/passes/prettify/RiddlFileEmitter.scala
@@ -62,6 +62,9 @@ case class RiddlFileEmitter(url: URL) extends FileBuilder {
         case d: Description      => emitDescription(d)
         case t: Term             => emitTerm(t)
         case a: AuthorRef        => emitAuthorRef(a)
+        case sa: StringAttachment => emitStringAttachment(sa)
+        case fa: FileAttachment => emitFileAttachment(fa)
+        case ua: ULIDAttachment => emitULIDAttachment(ua)
       }
       decr.add("}")
     end if
@@ -75,7 +78,7 @@ case class RiddlFileEmitter(url: URL) extends FileBuilder {
     end match
   end emitComment
 
-  def emitBriefDescription(brief: BriefDescription): this.type =
+  private def emitBriefDescription(brief: BriefDescription): this.type =
     addLine(brief.format)
   end emitBriefDescription
 
@@ -99,7 +102,7 @@ case class RiddlFileEmitter(url: URL) extends FileBuilder {
     this
   end emitDescription
 
-  def emitTerm(term: Term): this.type =
+  private def emitTerm(term: Term): this.type =
     addIndent("term ")
     add(term.id.format)
     add(" is ")
@@ -111,6 +114,16 @@ case class RiddlFileEmitter(url: URL) extends FileBuilder {
   def emitAuthorRef(authorRef: AuthorRef): this.type =
     addIndent("by ").add(authorRef.format).nl
   end emitAuthorRef
+  
+  private def emitStringAttachment(a: StringAttachment): this.type =
+    addIndent(a.identify).add(s" is \"${a.mimeType}\" as \"${a.value}\"")
+  end emitStringAttachment
+  
+  private def emitFileAttachment(a: FileAttachment): this.type =
+    addIndent(a.identify).add(s" is \"${a.mimeType} in file \"${a.inFile}\"")
+  
+  private def emitULIDAttachment(ulid: ULIDAttachment): this.type =
+    addIndent(ulid.identify)
 
   def emitString(s: String_): this.type = {
     (s.min, s.max) match {

--- a/passes/shared/src/main/scala/com/ossuminc/riddl/passes/validate/DefinitionValidation.scala
+++ b/passes/shared/src/main/scala/com/ossuminc/riddl/passes/validate/DefinitionValidation.scala
@@ -153,6 +153,9 @@ trait DefinitionValidation extends BasicValidation:
           )
         case _: AuthorRef   =>
           hasAuthorRef = true
+        case _: StringAttachment => ()
+        case _: FileAttachment => ()
+        case _: ULIDAttachment => () 
         case _: Description => ()
     }
     check(hasDescription,s"$identity should have a description", MissingWarning, definition.loc)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,8 @@ import sbt.librarymanagement.ModuleID
 /** V - Dependency Versions object */
 
 object V {
+  val airframe_json = "24.9.0"
+  val airframe_ulid = "24.9.0"
   val commons_io = "2.16.1"
   val compress = "1.27.1"
   val config = "1.4.2"


### PR DESCRIPTION
Allow:
* attachments in files or strings
* each attachment has a mime type
* ulids are handled specially to auto-create the attachment when you ask for the ulid value via an API method