### PR TITLE
Implement capturing URLs during parsing

### DIFF
--- a/language/shared/src/main/scala/com/ossuminc/riddl/language/parsing/ExtensibleTopLevelParser.scala
+++ b/language/shared/src/main/scala/com/ossuminc/riddl/language/parsing/ExtensibleTopLevelParser.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Ossum, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ossuminc.riddl.language.parsing
+
+import com.ossuminc.riddl.language.AST.*
+import com.ossuminc.riddl.language.Messages.Messages
+import com.ossuminc.riddl.language.{At, Messages}
+import com.ossuminc.riddl.utils.{CommonOptions, PlatformContext, Timer, URL}
+import fastparse.*
+import fastparse.MultiLineWhitespace.*
+
+import java.nio.file.{Files, Path}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.{ClassTag, classTag}
+import scala.scalajs.js.annotation.*
+
+/** An extensible version of the Top Level Parser. */
+
+trait ExtensibleTopLevelParser(using PlatformContext)
+    extends ProcessorParser
+    with DomainParser
+    with AdaptorParser
+    with ApplicationParser
+    with ContextParser
+    with EntityParser
+    with EpicParser
+    with FunctionParser
+    with ModuleParser
+    with NebulaParser
+    with ProjectorParser
+    with RepositoryParser
+    with RootParser
+    with SagaParser
+    with StreamingParser
+    with StatementParser
+    with ParsingContext {
+
+  def input: RiddlParserInput
+  def withVerboseFailures: Boolean
+  
+  private def doParse[E <: Parent: ClassTag](rule: P[?] => P[E]): Either[Messages, E] = {
+    parseRule[E](input, rule, withVerboseFailures) {
+      (result: Either[Messages, E], input: RiddlParserInput, index: Int) =>
+        result match {
+          case l: Left[Messages, E] => l
+          case result @ Right(node: E) =>
+            if node.contents.isEmpty then
+              error(At(input, index), s"Parser could not translate '${input.origin}' after $index characters")
+            end if
+            result
+          case _ @ Right(wrongNode) =>
+            val expected = classTag[E].runtimeClass
+            val actual = wrongNode.getClass
+            error(At(input, index), s"Parser did not yield a ${expected.getSimpleName} but ${actual.getSimpleName}")
+            Left(this.messagesAsList)
+        }
+    }
+  }
+  def parseRoot: Either[Messages, Root] = doParse[Root](root(_))
+
+  def parseNebula: Either[Messages, Nebula] = doParse[Nebula](nebula(_))
+
+  def parseRootWithURLs: Either[Messages, (Root, Seq[URL])] = {
+    doParse[Root](root(_)) match {
+      case l @ Left(messages) => Left(messages)
+      case r @ Right(root)    => Right(root -> this.getURLs)
+    }
+  }
+}

--- a/language/shared/src/main/scala/com/ossuminc/riddl/language/parsing/ParsingContext.scala
+++ b/language/shared/src/main/scala/com/ossuminc/riddl/language/parsing/ParsingContext.scala
@@ -19,11 +19,15 @@ import fastparse.Parsed.Success
 import scala.annotation.unused
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
+import scala.collection.mutable
 
 /** Unit Tests For ParsingContext */
 trait ParsingContext(using pc: PlatformContext) extends ParsingErrors {
 
   import fastparse.P
+
+  private val urlSeen: mutable.ListBuffer[URL] = mutable.ListBuffer[URL]()
+  def getURLs: Seq[URL] = urlSeen.toSeq
 
   def parseRule[RESULT <: RiddlValue](
     rpi: RiddlParserInput,
@@ -79,6 +83,7 @@ trait ParsingContext(using pc: PlatformContext) extends ParsingErrors {
       }
       ctx.input.asInstanceOf[RiddlParserInput].root.parent.resolve(name)
     }
+    urlSeen.append(newURL)
     try {
       import com.ossuminc.riddl.utils.Await
       implicit val ec: ExecutionContext = pc.ec

--- a/language/shared/src/main/scala/com/ossuminc/riddl/language/parsing/TopLevelParser.scala
+++ b/language/shared/src/main/scala/com/ossuminc/riddl/language/parsing/TopLevelParser.scala
@@ -7,71 +7,30 @@
 package com.ossuminc.riddl.language.parsing
 
 import com.ossuminc.riddl.language.AST.*
-import com.ossuminc.riddl.language.At
+import com.ossuminc.riddl.language.{At, Messages}
 import com.ossuminc.riddl.language.Messages.Messages
-import com.ossuminc.riddl.utils.{PlatformContext, Timer, CommonOptions}
+import com.ossuminc.riddl.utils.{CommonOptions, PlatformContext, Timer, URL}
 import fastparse.*
 import fastparse.MultiLineWhitespace.*
 
 import java.nio.file.{Files, Path}
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.{ClassTag, classTag}
 import scala.scalajs.js.annotation.*
 
-/** The TopLevel (Root) parser. This class
-  * @param commonOptions
-  *   Common options to use during the parsing
+/** The TopLevel (Root) parser. This class munges all the individual parsers together and provides top level parsing
+  * functionality.
+  * @param input
+  *   The RiddlParserInput that contains the data to parse
+  * @param withVerboseFailures
+  *   For the utility of RIDDL implementers.
   */
 @JSExportTopLevel("TopLevelParser")
-class TopLevelParser(using io: PlatformContext)
-    extends ProcessorParser
-    with DomainParser
-    with AdaptorParser
-    with ApplicationParser
-    with ContextParser
-    with EntityParser
-    with EpicParser
-    with FunctionParser
-    with ModuleParser
-    with NebulaParser
-    with ProjectorParser
-    with RepositoryParser
-    with RootParser
-    with SagaParser
-    with StreamingParser
-    with StatementParser
-    with ParsingContext {
-
-  @JSExport
-  def parseRoot(input: RiddlParserInput, withVerboseFailures: Boolean = false): Either[Messages, Root] = {
-    parseRule[Root](input, root(_), withVerboseFailures) {
-      (result: Either[Messages, Root], input: RiddlParserInput, index: Int) =>
-        result match {
-          case l: Left[Messages, Root] => l
-          case r @ Right(root) =>
-            if root.contents.isEmpty then
-              error(At(input, index), s"Parser could not translate '${input.origin}' after $index characters")
-            end if
-            r
-        }
-    }
-  }
-
-  @JSExport
-  def parseNebula(input: RiddlParserInput, withVerboseFailures: Boolean = false): Either[Messages, Nebula] = {
-    parseRule[Nebula](input, nebula(_), withVerboseFailures) {
-      (result: Either[Messages, Nebula], input: RiddlParserInput, index: Int) =>
-        result match {
-          case left: Left[Messages, Root] => left
-          case r @ Right(root) =>
-            if root.contents.isEmpty then
-              error(At(input, index), s"Parser could not translate '${input.origin}' after $index characters")
-            end if
-            r
-        }
-    }
-  }
-}
+case class TopLevelParser(
+  input: RiddlParserInput,
+  withVerboseFailures: Boolean
+)(using io: PlatformContext) extends ExtensibleTopLevelParser
 
 @JSExportTopLevel("TopLevelParser$")
 object TopLevelParser {
@@ -84,8 +43,6 @@ object TopLevelParser {
     * parser.
     * @param url
     *   A `file://` or `https://` based url to specify the source of the parser input
-    * @param commonOptions
-    *   Options relevant to parsing the input
     * @param withVerboseFailures
     *   Control whether parse failures are diagnosed verbosely or not. Typically only useful to maintainers of RIDDL, or
     *   test cases
@@ -96,7 +53,8 @@ object TopLevelParser {
   )(using io: PlatformContext): Future[Either[Messages, Root]] = {
     io.load(url).map { (data: String) =>
       val rpi = RiddlParserInput(data.mkString, url)
-      parseInput(rpi, withVerboseFailures)
+      val tlp = new TopLevelParser(rpi, withVerboseFailures)
+      tlp.parseRoot
     }
   }
 
@@ -104,8 +62,6 @@ object TopLevelParser {
     * RiddlParserInput from a string and call this to start parsing.
     * @param input
     *   The RiddlParserInput that contains the data to parse
-    * @param commonOptions
-    *   The common options that could affect parsing or its output
     * @param withVerboseFailures
     *   For the utility of RIDDL implementers.
     * @return
@@ -116,8 +72,8 @@ object TopLevelParser {
   )(using io: PlatformContext): Either[Messages, Root] = {
     Timer.time(s"parse ${input.origin}", io.options.showTimes) {
       implicit val _: ExecutionContext = io.ec
-      val tlp = new TopLevelParser()
-      tlp.parseRoot(input, withVerboseFailures)
+      val tlp = new TopLevelParser(input, withVerboseFailures)
+      tlp.parseRoot
     }
   }
 
@@ -126,7 +82,8 @@ object TopLevelParser {
     withVerboseFailures: Boolean = false
   )(using PlatformContext): Either[Messages, Root] = {
     val rpi = RiddlParserInput(input, "")
-    parseInput(rpi)
+    val tlp = new TopLevelParser(rpi, withVerboseFailures)
+    tlp.parseRoot
   }
 
   def parseNebulaFromInput(
@@ -134,9 +91,8 @@ object TopLevelParser {
     withVerboseFailures: Boolean = false
   )(using io: PlatformContext): Either[Messages, Nebula] = {
     Timer.time(s"parse nebula from ${input.origin}", io.options.showTimes) {
-      implicit val _: ExecutionContext = io.ec
-      val tlp = new TopLevelParser()
-      tlp.parseNebula(input, withVerboseFailures)
+      val tlp = new TopLevelParser(input, withVerboseFailures)
+      tlp.parseNebula
     }
   }
 }

--- a/language/shared/src/test/scala/com/ossuminc/riddl/language/parsing/AbstractParsingTest.scala
+++ b/language/shared/src/test/scala/com/ossuminc/riddl/language/parsing/AbstractParsingTest.scala
@@ -21,8 +21,9 @@ import scala.reflect.*
 /** A helper class for testing the parser */
 trait AbstractParsingTest(using PlatformContext) extends AbstractTestingBasisWithTestData {
 
-  case class StringParser(content: String, testCase: String = "unknown test case") extends TopLevelParser():
-    val rpi = RiddlParserInput(content, testCase)
+  case class StringParser(content: String, testCase: String = "unknown test case") extends ExtensibleTopLevelParser():
+    val input: RiddlParserInput = RiddlParserInput(content, testCase)
+    val withVerboseFailures: Boolean = true 
   end StringParser
 
   def parse[T <: RiddlValue, U <: RiddlValue](
@@ -51,7 +52,7 @@ trait AbstractParsingTest(using PlatformContext) extends AbstractTestingBasisWit
 
   def parseNebula(input: RiddlParserInput): Either[Messages, Nebula] = {
     val tp = TestParser(input)
-    tp.parseNebula(input)
+    tp.parseNebula
   }
 
   def parseDomainDefinition[TO <: RiddlValue](

--- a/language/shared/src/test/scala/com/ossuminc/riddl/language/parsing/TestParser.scala
+++ b/language/shared/src/test/scala/com/ossuminc/riddl/language/parsing/TestParser.scala
@@ -20,10 +20,11 @@ import scala.util.control.NonFatal
 
 case class TestParser(
   input: RiddlParserInput,
-  throwOnError: Boolean = false
-)(using PlatformContext) extends TopLevelParser()
+  throwOnError: Boolean = false,
+  withVerboseFailures: Boolean = true
+)(using PlatformContext) extends ExtensibleTopLevelParser
     with Matchers {
-
+  
   def expect[CT <: RiddlValue](
     parser: P[?] => P[CT],
     withVerboseFailures: Boolean = false
@@ -75,19 +76,15 @@ case class TestParser(
     }
     parser.asInstanceOf[P[?] => P[T]]
   }
-
-  def parseRoot: Either[Messages, Root] = {
-    parseRoot(input, withVerboseFailures = true)
-  }
-
+  
   def parseTopLevelDomains: Either[Messages, Root] = {
-    parseRoot(input, withVerboseFailures = true)
+    parseRoot
   }
 
   def parseTopLevelDomain[TO <: RiddlValue](
     extract: Root => TO
   ): Either[Messages, TO] = {
-    parseRoot(input, withVerboseFailures = true).map { (root: Root) => extract(root) }
+    parseRoot.map { (root: Root) => extract(root) }
   }
 
   def parseDefinition[FROM <: Definition: ClassTag, TO <: RiddlValue](

--- a/passes/shared/src/main/scala/com/ossuminc/riddl/passes/validate/BasicValidation.scala
+++ b/passes/shared/src/main/scala/com/ossuminc/riddl/passes/validate/BasicValidation.scala
@@ -12,7 +12,7 @@ import com.ossuminc.riddl.language.Messages
 import com.ossuminc.riddl.language.{AST, At}
 import com.ossuminc.riddl.passes.resolve.ResolutionOutput
 import com.ossuminc.riddl.passes.symbols.SymbolsOutput
-import com.ossuminc.riddl.utils.{pc, ec}
+import com.ossuminc.riddl.utils.pc
 
 import scala.reflect.{ClassTag, classTag}
 import scala.util.matching.Regex


### PR DESCRIPTION
* ParserContext just keeps a list of every file imported.
* New method TopLevelParser.parseRootWithURLs
* Abstract out ExtensibleTopLevelParser
* Eliminate code redundancy in TopLevelParser